### PR TITLE
Fix enough things to repair the encoder

### DIFF
--- a/extern/agidl/src/agidl_img_types.c
+++ b/extern/agidl/src/agidl_img_types.c
@@ -56,7 +56,7 @@ char* AGIDL_StrCpy(const char *a, const char *b){
 }
 
 char* AGIDL_GetImgExtension(const AGIDL_IMG_TYPE img){
-	char* ext = malloc(sizeof(char)*4);
+	char* ext = malloc(sizeof(char)*5);
 	switch(img){
 		case AGIDL_IMG_BMP:{
 			strcpy(ext,".bmp");

--- a/src/agmv_encode.c
+++ b/src/agmv_encode.c
@@ -681,6 +681,15 @@ void AGMV_EncodeAudioChunk(FILE* file, const AGMV* agmv){
 	}
 }
 
+typedef struct histogram_colorgram_pair_type {
+	u32 histogram;
+	u32 colorgram;
+} histogram_colorgram_pair_type;
+
+static int histogram_colorgram_pair_compare(const void* lhs, const void* rhs) {
+	return ((histogram_colorgram_pair_type*) lhs)->histogram - ((histogram_colorgram_pair_type*) rhs)->histogram;
+}
+
 void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basename, u8 img_type, u32 start_frame, u32 end_frame, u32 width, u32 height, u32 frames_per_second, AGMV_OPT opt, AGMV_QUALITY quality, AGMV_COMPRESSION compression){
 	u32 i, palette0[256], palette1[256], n, count = 0, num_of_frames_encoded = 0, w, h, num_of_pix, max_clr;
 	u32 pal[512];
@@ -704,8 +713,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 		}break;
 	}
 
-	u32* colorgram = malloc(sizeof(u32)*max_clr);
-	u32* histogram = malloc(sizeof(u32)*max_clr);
+	histogram_colorgram_pair_type* histogram_colorgram_pair = malloc(sizeof(histogram_colorgram_pair)*max_clr);
 
 	switch(opt){
 		case AGMV_OPT_I:{
@@ -771,8 +779,8 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 	}
 
 	for(i = 0; i < max_clr; i++){
-		histogram[i] = 1;
-		colorgram[i] = i;
+		histogram_colorgram_pair[i].histogram = 1;
+		histogram_colorgram_pair[i].colorgram = i;
 	}
 
 	char* ext = AGIDL_GetImgExtension(img_type);
@@ -799,7 +807,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeBMP(bmp);
@@ -816,7 +824,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeTGA(tga);
@@ -832,7 +840,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeTIM(tim);
@@ -848,7 +856,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreePCX(pcx);
@@ -864,7 +872,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeLMP(lmp);
@@ -880,7 +888,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreePVR(pvr);
@@ -896,7 +904,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeGXT(gxt);
@@ -912,7 +920,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeBTI(bti);
@@ -928,7 +936,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_Free3DF(glide);
@@ -944,7 +952,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreePPM(ppm);
@@ -960,7 +968,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 				for(n = 0; n < width*height; n++){
 					u32 color = pixels[n];
 					u32 hcolor = AGMV_QuantizeColor(color,quality);
-					histogram[hcolor] = histogram[hcolor] + 1;
+					histogram_colorgram_pair[hcolor].histogram = histogram_colorgram_pair[hcolor].histogram + 1;
 				}
 
 				AGIDL_FreeLBM(lbm);
@@ -968,12 +976,13 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 		}
 	}
 
-	AGMV_QuickSort(histogram,colorgram,0,max_clr);
+	qsort(histogram_colorgram_pair, max_clr, sizeof(histogram_colorgram_pair_type), histogram_colorgram_pair_compare);
+	// AGMV_QuickSort(histogram,colorgram,0,max_clr);
 
 	for(n = max_clr; n > 0; n--){
 		Bool skip = FALSE;
 
-		u32 clr = colorgram[n];
+		u32 clr = histogram_colorgram_pair[n].colorgram;
 
 		int r = AGMV_GetQuantizedR(clr,quality);
 		int g = AGMV_GetQuantizedG(clr,quality);
@@ -1056,8 +1065,7 @@ void AGMV_EncodeVideo(const char* filename, const char* dir, const char* basenam
 		}
 	}
 
-	free(colorgram);
-	free(histogram);
+	free(histogram_colorgram_pair);
 
 	FILE* file = fopen(filename,"wb");
 

--- a/src/agmv_utils.c
+++ b/src/agmv_utils.c
@@ -327,7 +327,13 @@ AGMV* CreateAGMV(const u32 num_of_frames, const u32 width, const u32 height, con
 	agmv->iframe_entries = (AGMV_ENTRY*)malloc(sizeof(AGMV_ENTRY)*width*height);
 
 	agmv->frame_count = 0;
+	agmv->audio_chunk->fourcc[0] = 0;
+	agmv->audio_chunk->size = 0;
+	agmv->audio_chunk->atsample = NULL;
+	agmv->audio_chunk->satsample = NULL;
+	agmv->audio_track->total_audio_duration = 0;
 	agmv->audio_track->start_point = 0;
+	agmv->audio_track->pcm = NULL;
 
 	AGMV_SetWidth(agmv,width);
 	AGMV_SetHeight(agmv,height);
@@ -371,17 +377,16 @@ void DestroyAGMV(AGMV* agmv){
 
 		free(agmv->bitstream);
 		free(agmv->frame_chunk);
-		free(agmv->audio_chunk);
 
 		if(agmv->audio_track->pcm != NULL){
 			free(agmv->audio_track->pcm);
 		}
+		free(agmv->audio_track);
 
 		if(agmv->audio_chunk->atsample != NULL){
 			free(agmv->audio_chunk->atsample);
 		}
-
-		free(agmv->audio_track);
+		free(agmv->audio_chunk);
 
 		agmv = NULL;
 	}
@@ -921,7 +926,7 @@ void QQSwap(u32* a, u32* b){
 int ppartition(u32* data, u32* gram, const int low, const int high)
 {
     // choose the pivot
-    const int pivot = data[high];
+    const u32 pivot = data[high];
 
     // Index of smaller element and Indicate
     // the right position of pivot found so far

--- a/tools/agmvcli/agmvcli.c
+++ b/tools/agmvcli/agmvcli.c
@@ -77,7 +77,7 @@ int main(const int argc, char* argv[]){
 		return 1;
 	}
 	if(mode[0] == 'E' && mode[1] == 'N' && mode[2] == 'C'){
-		char filename[100], directory[30], basename[30], type[3], opt[11], qopt[6], compression[5], at[3], track[100];
+		char filename[100], directory[30], basename[30], type[4], opt[12], qopt[6], compression[5], at[3], track[100];
 		u32 start_frame, end_frame, width, height, fps;
 		fscanf(file,"%s %s %s %s %ld %ld %ld %ld %ld %s %s %s %s %s",filename,directory,basename,type,&start_frame,&end_frame,&width,&height,&fps,opt,qopt,compression,at,track);
 


### PR DESCRIPTION
- AGMV_QuickSort is crashing, so for now I replaced it with the C standard library quick-sort (qsort)
- AGIDL_GetImgExtension was writing 1-past-the-buffer
- CreateAGMV left uninitialised pointers: resulting in free being called on invalid pointers, this was a big crash
- agmv->audio_chunk was being freed, and then it was being read by its members, resulting in a memory leak + crash
- ppartition compares signed int with u32: this doesn't fix the crash, but it looks like a bug
- type and opt were not big enough for the NUL byte of scanf: this was the missing base-name issue that I reported on Discord